### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,24 +6,24 @@
 # Datatypes (KEYWORD1)
 ##########################################
 
-Connector		KEYWORD1
+Connector	KEYWORD1
 
 ##########################################
 # Methods and Functions (KEYWORD2)
 ##########################################
 
-cmd_query		KEYWORD2
-cmd_query_P   KEYWORD2
+cmd_query	KEYWORD2
+cmd_query_P	KEYWORD2
 mysql_connect	KEYWORD2
 show_results	KEYWORD2
-get_field		KEYWORD2
-get_row			KEYWORD2
+get_field	KEYWORD2
+get_row	KEYWORD2
 is_connected	KEYWORD2
 
 ##########################################
 # Constants (LITERAL1)
 ##########################################
 
-ok_packet		LITERAL1
-eof_packet		LITERAL1
-field_struct  LITERAL1
+ok_packet	LITERAL1
+eof_packet	LITERAL1
+field_struct	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords